### PR TITLE
Use a SurfaceCallback to trace surface destruction / creation

### DIFF
--- a/app/src/main/java/com/sicaus/patapov/services/camera/Camera.kt
+++ b/app/src/main/java/com/sicaus/patapov/services/camera/Camera.kt
@@ -30,6 +30,13 @@ interface Camera: ActivityBound, RequiringPermissions {
     suspend fun subscribe(surface: Surface)
 
     /**
+     * Unsubscribes a surface from the camera stream.
+     * Unsubscribing a surface restarts the camera.
+     * If there are no subscriptors, the camera is stopped.
+     */
+    suspend fun unsubscribe(surface: Surface)
+
+    /**
      * Stops the camera.
      * It is possible to stop the camera from outside the user interface.
      * If the camera didn't start, then this method does nothing.

--- a/app/src/main/java/com/sicaus/patapov/services/camera/CameraImpl.kt
+++ b/app/src/main/java/com/sicaus/patapov/services/camera/CameraImpl.kt
@@ -228,6 +228,12 @@ class CameraImpl: Camera {
     }
 
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    override suspend fun unsubscribe(surface: Surface) {
+        targets.remove(surface)
+        restart()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     private suspend fun restart() {
         lock.lock()
 
@@ -240,6 +246,11 @@ class CameraImpl: Camera {
         if (currentState is InnerState.CameraInSession) {
             currentState.captureSession.close()
             currentState.device.close()
+        }
+
+        if (targets.isEmpty()) {
+            state = InnerState.CameraStandby(currentState)
+            return
         }
 
         val device = openCameraDevice(currentState.selectedCameraDescription.cameraId)

--- a/app/src/main/java/com/sicaus/patapov/ui/composables/CameraPreviewSurfaceView.kt
+++ b/app/src/main/java/com/sicaus/patapov/ui/composables/CameraPreviewSurfaceView.kt
@@ -12,7 +12,15 @@ import com.sicaus.patapov.services.camera.SelectedCameraDescription
  * A custom [TextureView], adapted for camera preview.
  */
 @SuppressLint("ViewConstructor") // No need of view constructor, as we're using jetpack.
-class CameraPreviewTextureView(private val cameraDescription: SelectedCameraDescription, context: Context): SurfaceView(context) {
+class CameraPreviewSurfaceView(
+    private val cameraDescription: SelectedCameraDescription,
+    context: Context): SurfaceView(context) {
+
+    /**
+     * Sets the size of the inner surface.
+     * The camera session picks the camera resolution from the size of the surface, so it
+     * is important to match one of the available resolutions.
+     */
     init {
         this.holder.setFixedSize(
             cameraDescription.sizeInPixels.width,
@@ -20,18 +28,8 @@ class CameraPreviewTextureView(private val cameraDescription: SelectedCameraDesc
     }
 
     /**
-     * Recalculates the scale required for the camera output to be displayed on the view without
-     * distortion.
-     * [android.view.View] scales the content so as to cover the whole area,
-     * not concerned by preserving the aspect ratio.
-     * Things to consider in the calculation:
-     * - The camera output
-     *   - The size of the sensor, in mm - its physical size.
-     *   - The size of the output, in pixels
-     * - The view actual size
-     *   - The view size measured by the [onMeasure] method.
-     *   - This method is called when the view need to resize itself - at first display, or
-     *   after a rotation, or after any event that affects its size.
+     * Recalculates the scale required for the camera output to be displayed on the
+     * view without distortion.
      */
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         // Don't interfere with the normal measure procedure:
@@ -54,11 +52,13 @@ class CameraPreviewTextureView(private val cameraDescription: SelectedCameraDesc
         }
 
         // Camara output aspect and measured view aspect:
-        val cameraOutputAspect = cameraOutputWidth.toFloat() / cameraOutputHeight.toFloat()
-        val measuredAspect = measuredWidth.toFloat() / measuredHeight.toFloat()
+        val cameraOutputAspect =
+            cameraOutputWidth.toFloat() / cameraOutputHeight.toFloat()
+        val measuredAspect =
+            measuredWidth.toFloat() / measuredHeight.toFloat()
 
-        // Surface will be stretched to completely fit the measured area. We want the scale
-        // to do the inverse:
+        // Surface will be stretched to completely fit the measured area.
+        // We want the scale to do the inverse:
         val scaleAspect = cameraOutputAspect / measuredAspect
 
         if (scaleAspect < 1) {

--- a/app/src/main/java/com/sicaus/patapov/ui/screens/cameracontrol/CameraControlViewModel.kt
+++ b/app/src/main/java/com/sicaus/patapov/ui/screens/cameracontrol/CameraControlViewModel.kt
@@ -1,5 +1,6 @@
 package com.sicaus.patapov.ui.screens.cameracontrol
 
+import android.util.Log
 import android.view.Surface
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -108,6 +109,29 @@ open class CameraControlViewModel(
                 }
             }
         }
+    }
+
+    /**
+     * UI calls this method to provide a [Surface] to subscribe to the camera.
+     */
+    open fun deactivateCamera(surface: Surface) {
+        if (_uiState.value.cameraState == ServiceState.RUNNING) {
+            viewModelScope.launch {
+                try {
+                    camera.unsubscribe(surface)
+                    _uiState.update {
+                        it.copy(cameraState = ServiceState.STARTING_UP)
+                    }
+                } catch (e: CameraException) {
+                    _uiState.update {
+                        it.copy(
+                            cameraState = ServiceState.ERROR,
+                            exception = e)
+                    }
+                }
+            }
+        }
+
     }
 
     open fun stopCamera() {


### PR DESCRIPTION
Device rotation triggers a surface destruction and reconstruction.

Closes #3 